### PR TITLE
Fix creating commands where the prefix exists

### DIFF
--- a/plugin/bufkill.vim
+++ b/plugin/bufkill.vim
@@ -203,7 +203,7 @@ call s:Debug(2, 'g:BufKillCommandPrefix')
 "
 function! <SID>CreateUniqueCommand(lhs, rhs)
   let command = g:BufKillCommandPrefix.a:lhs
-  if !exists(':'.command)
+  if exists(':'.command) < 2
     exe 'command -bang '.command.' '.a:rhs
   endif
 endfunction


### PR DESCRIPTION
`exists(":Foo")` returns 1, if there is a command `Foobar` already.

With an existing command `BDOnly`, `BD` should still get created.
