### PR TITLE
Handle BufAdd event

### DIFF
--- a/plugin/bufkill.vim
+++ b/plugin/bufkill.vim
@@ -736,6 +736,7 @@ augroup BufKill
 autocmd!
 autocmd BufKill WinEnter * call <SID>UpdateList('WinEnter')
 autocmd BufKill BufEnter * call <SID>UpdateList('BufEnter')
+autocmd BufKill BufAdd * call <SID>UpdateList('BufAdd')
 autocmd BufKill WinLeave * call <SID>UpdateLastColumn('WinLeave')
 autocmd BufKill BufLeave * call <SID>UpdateLastColumn('BufLeave')
 augroup END


### PR DESCRIPTION
This is a fix for issue #12.

I was seeing the same "UpdateLastColumn failed to find bufnr" error message when opening files from NERDTree. I tried netrw and encountered the same problem, so I turned on debug logs to see what was going on.

When you have a directory list buffer in netrw and hit Enter on a file, netrw does a bwipe to clear out the directory list. This results in a BufLeave event for the outgoing directory buffer and a BufAdd event for the empty buffer replacing it. I noticed that there was no BufEnter event for that empty buffer. The next thing netrw does is edit the selected file. This results in a BufLeave for the empty buffer and a BufEnter for the file. vim-bufkill did not catch the BufAdd event so that produced the error message on the BufLeave event.
